### PR TITLE
Fix build errors in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build firmware
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            git build-essential cmake ninja-build ccache \
+            flex bison gperf python3 python3-pip python3-venv \
+            libffi-dev libssl-dev dfu-util libusb-1.0-0 \
+            pkg-config curl ca-certificates
+
+      - name: Cache ESP-IDF tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.espressif
+          key: ${{ runner.os }}-espressif-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-espressif-
+
+      - name: Cache components checkout
+        uses: actions/cache@v4
+        with:
+          path: |
+            components
+          key: ${{ runner.os }}-components-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-components-
+
+      - name: Build firmware
+        run: |
+          make -j$(nproc)
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-binaries
+          path: |
+            firmware/*.bin
+          if-no-files-found: error
+

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ESPIDF_URL=file://$(LOCAL_GIT_DIR)/esp-idf
 ESPHK_URL=file://$(LOCAL_GIT_DIR)/esp-homekit-sdk
 else
 MPY_URL=https://github.com/micropython/micropython/
-ESPIDF_URL=http://github.com/espressif/esp-idf
+ESPIDF_URL=https://github.com/espressif/esp-idf
 ESPHK_URL=https://github.com/espressif/esp-homekit-sdk
 endif
 


### PR DESCRIPTION
Add a GitHub Actions workflow and update ESP-IDF URL to enable continuous integration builds and prevent clone failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-24b2749a-5fc7-4f05-8e1c-7a24a3f01891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24b2749a-5fc7-4f05-8e1c-7a24a3f01891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

