### PR TITLE
Setup and patch esp-homekit sdk

### DIFF
--- a/patch/esp-homekit-sdk/0001-allow-characteristic-private-access.patch
+++ b/patch/esp-homekit-sdk/0001-allow-characteristic-private-access.patch
@@ -1,12 +1,11 @@
 diff --git a/components/homekit/esp_hap_core/include/hap.h b/components/homekit/esp_hap_core/include/hap.h
-index fdd80f5..b7b5e57 100644
+index 19bccb7..674d4cd 100644
 --- a/components/homekit/esp_hap_core/include/hap.h
 +++ b/components/homekit/esp_hap_core/include/hap.h
-@@ -1565,6 +1565,28 @@ void hap_http_debug_disable();
-  * @return NULL on failure.
+@@ -1591,6 +1591,27 @@ void hap_http_debug_disable();
   */
  char *esp_hap_get_setup_payload(char *setup_code, char *setup_id, bool wac_support, hap_cid_t cid);
-+
+ 
 +/**
 + * @brief Set characteristic private data
 + *
@@ -18,24 +17,24 @@ index fdd80f5..b7b5e57 100644
 +/**
 + * @brief Get characteristic private
 + *
-+ * @param[in] hs HAP characteristic Object Handle
++ * @param[in] hc HAP characteristic Object Handle
 + *
 + * @return Pointer to the private data (can be NULL)
 + */
 +void *hap_char_get_priv(hap_char_t *hc);
 +
 +#if CONFIG_HAP_HTTP_SERVER_PORT == 80
-+	#error "Homekit server on port 80"
++#error "Homekit server on port 80"
 +#endif
 +
- #ifdef __cplusplus
- }
- #endif
+ /* Re-enable Pair Setup
+  *
+  * This API can be used to re-enable pair setup after it has timed out
 diff --git a/components/homekit/esp_hap_core/src/esp_hap_char.c b/components/homekit/esp_hap_core/src/esp_hap_char.c
-index 9b712e3..9c43ac9 100644
+index a320157..afe8848 100644
 --- a/components/homekit/esp_hap_core/src/esp_hap_char.c
 +++ b/components/homekit/esp_hap_core/src/esp_hap_char.c
-@@ -599,3 +599,32 @@ void hap_char_add_valid_vals_range(hap_char_t *hc, uint8_t start_val, uint8_t en
+@@ -609,3 +609,32 @@ void hap_char_add_valid_vals_range(hap_char_t *hc, uint8_t start_val, uint8_t en
          _hc->valid_vals_range[1] = end_val;
      }
  }
@@ -56,7 +55,7 @@ index 9b712e3..9c43ac9 100644
 +/**
 + * @brief Get characteristic private
 + *
-+ * @param[in] hs HAP characteristic Object Handle
++ * @param[in] hc HAP characteristic Object Handle
 + *
 + * @return Pointer to the private data (can be NULL)
 + */
@@ -69,14 +68,14 @@ index 9b712e3..9c43ac9 100644
 +    }
 +}
 diff --git a/components/homekit/esp_hap_core/src/priv_includes/esp_hap_char.h b/components/homekit/esp_hap_core/src/priv_includes/esp_hap_char.h
-index d24fcf8..0ef3764 100644
+index 967fede..36575cc 100644
 --- a/components/homekit/esp_hap_core/src/priv_includes/esp_hap_char.h
 +++ b/components/homekit/esp_hap_core/src/priv_includes/esp_hap_char.h
 @@ -81,6 +81,7 @@ typedef struct  {
      uint8_t *valid_vals;
      size_t valid_vals_cnt;
      bool update_called;
-+    void * priv;
++    void *priv;
  } __hap_char_t;
  
  void hap_char_manage_notification(hap_char_t *hc, int index, bool ev);


### PR DESCRIPTION
Update `0001-allow-characteristic-private-access.patch` to apply cleanly against `esp-homekit-sdk` commit `bfbcd6e749635d97645380b9d7b32274553fe017`.

The previous patch failed to apply during CI/CD due to offset drift in the upstream `esp-homekit-sdk` repository. This PR regenerates the patch to correctly introduce `hap_char_set_priv`, `hap_char_get_priv` functions, a `priv` field in `__hap_char_t`, and a port 80 check, ensuring the build process can proceed.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a766646-1e7d-40fe-bd34-49e6a407eca6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a766646-1e7d-40fe-bd34-49e6a407eca6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

